### PR TITLE
Close connection before retry

### DIFF
--- a/main.go
+++ b/main.go
@@ -153,10 +153,10 @@ func (c *Client) pester(p params) (*http.Response, error) {
 
 	// re-create the http client so we can leverage the std lib
 	httpClient := http.Client{
-		Transport:     c.hc.Transport,
-		CheckRedirect: c.hc.CheckRedirect,
-		Jar:           c.hc.Jar,
-		Timeout:       c.hc.Timeout,
+		Transport:     c.Transport,
+		CheckRedirect: c.CheckRedirect,
+		Jar:           c.Jar,
+		Timeout:       c.Timeout,
 	}
 
 	// if we have a request body, we need to save it for later

--- a/main.go
+++ b/main.go
@@ -210,9 +210,12 @@ func (c *Client) pester(p params) (*http.Response, error) {
 				}
 
 				// 200 and 300 level errors are considered success and we are done
-				if err == nil && resp.StatusCode < 400 {
-					resultCh <- result{resp: resp, err: err, req: n, retry: i}
-					return
+				if err == nil {
+					if resp.StatusCode < 400 {
+						resultCh <- result{resp: resp, err: err, req: n, retry: i}
+						return
+					}
+					resp.Body.Close()
 				}
 
 				c.log(ErrEntry{


### PR DESCRIPTION
It's a serious bug. If we create a request and the response code >= 400, we have to close the connection before trying another request.

In case we create a lot of requests and run in multi goroutines, the number of connection in WAIT_CLOSE status will be increased fast and lead to the "too many open files" issue.
```
Jan 14 01:55:25 [13884]: 2016/01/14 01:55:25 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s
Jan 14 01:55:26 [13884]: 2016/01/14 01:55:26 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s
Jan 14 01:55:27 [13884]: 2016/01/14 01:55:27 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s
Jan 14 01:55:28 [13884]: 2016/01/14 01:55:28 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s
Jan 14 01:55:29 [13884]: 2016/01/14 01:55:29 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s
Jan 14 01:55:30 [13884]: 2016/01/14 01:55:30 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s
Jan 14 01:55:31 [13884]: 2016/01/14 01:55:31 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s
Jan 14 01:55:32 [13884]: 2016/01/14 01:55:32 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s
Jan 14 01:55:33 [13884]: 2016/01/14 01:55:33 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s
Jan 14 01:55:34 [13884]: 2016/01/14 01:55:34 http: Accept error: accept tcp [::]:15110: too many open files; retrying in 1s