### PR TITLE
Only retry for 5xx status codes

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,8 +209,8 @@ func (c *Client) pester(p params) (*http.Response, error) {
 					resp, err = httpClient.PostForm(p.url, p.data)
 				}
 
-				// 200 and 300 level errors are considered success and we are done
-				if err == nil && resp.StatusCode < 400 {
+				// Only retry on 5xx status codes
+				if err == nil && resp.StatusCode < 500 {
 					resultCh <- result{resp: resp, err: err, req: n, retry: i}
 					return
 				}


### PR DESCRIPTION
4xx errors are for situations in which the client seems to have erred,
and we should not expect that retrying will result in success. 5xx
errors, however, are for when the server failed to fulfill an apparently
valid request, which may succeed on retry.

Signed-off-by: Kris Hicks <khicks@pivotal.io>