### PR TITLE
Only close body when using concurrency

### DIFF
--- a/main.go
+++ b/main.go
@@ -233,9 +233,11 @@ func (c *Client) pester(p params) (*http.Response, error) {
 				// Only retry on 5xx status codes
 				if err == nil && resp.StatusCode < 500 {
 					resultCh <- result{resp: resp, err: err, req: n, retry: i}
-					// close the resp body because the client wont get their own opportunity for it
-					// fixed by github.com/ninhdh0 (thanks mate!)
-					resp.Body.Close()
+					if concurrency > 1 {
+						// close the resp body because the client wont get their own opportunity for it
+						// fixed by github.com/ninhdh0 (thanks mate!)
+						resp.Body.Close()
+					}
 					return
 				}
 


### PR DESCRIPTION
Response body are closed so users of pester will not be able to consume the Body. This PR will make it so that closing is only done when using pester with concurrency.