### PR TITLE
go fmt complete

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"errors"
 	"net/http"
 	"net/http/cookiejar"
-	"errors"
 )
 
 func TestConcurrentRequests(t *testing.T) {
@@ -104,17 +104,17 @@ func TestDefaultBackoff(t *testing.T) {
 func TestFormatError(t *testing.T) {
 	t.Parallel()
 	err := errors.New("Get http://localhost:9000/foo: dial tcp 127.0.0.1:9000: getsockopt: connection refused")
-	expected := "1491271979 Get [GET] http://localhost:9000/foo request-0 retry-2 error: "+ err.Error()+"\n"
+	expected := "1491271979 Get [GET] http://localhost:9000/foo request-0 retry-2 error: " + err.Error() + "\n"
 
 	e := ErrEntry{
-		Time: time.Unix(1491271979, 0),
-		Method: "Get",
-		URL: "http://localhost:9000/foo",
-		Verb: http.MethodGet,
+		Time:    time.Unix(1491271979, 0),
+		Method:  "Get",
+		URL:     "http://localhost:9000/foo",
+		Verb:    http.MethodGet,
 		Request: 0,
-		Retry: 2,
+		Retry:   2,
 		Attempt: 1,
-		Err: err,
+		Err:     err,
 	}
 
 	c := New()


### PR DESCRIPTION
`main_test.go` isn't properly format, PR containing `go fmt` on the package directory.