### PR TITLE
Make retries cancelable

### DIFF
--- a/pester.go
+++ b/pester.go
@@ -300,6 +300,16 @@ func (c *Client) pester(p params) (*http.Response, error) {
 					return
 				}
 
+				//If the request has been cancelled, skip retries
+				if p.req != nil {
+					ctx := p.req.Context()
+					select {
+					case <-ctx.Done():
+						multiplexCh <- result{resp: resp, err: ctx.Err()}
+						return
+					}
+				}
+
 				// if we are retrying, we should close this response body to free the fd
 				if resp != nil {
 					resp.Body.Close()


### PR DESCRIPTION
Make retries cancelable

When using a request.WithContext it is possible to cancel a long running
request.  However, when using a cancelable request with retries enabled,
we want to quit the retry loop.

This is impactful when using a conservative backoff strategy and a
large number of retries.