### PR TITLE
Set a default case so loop can continue when checking for context 

### DIFF
--- a/pester.go
+++ b/pester.go
@@ -307,6 +307,7 @@ func (c *Client) pester(p params) (*http.Response, error) {
 					case <-ctx.Done():
 						multiplexCh <- result{resp: resp, err: ctx.Err()}
 						return
+					default:
 					}
 				}
 


### PR DESCRIPTION
cancellation

fixes #28 